### PR TITLE
Add dynamic pagination for jobs

### DIFF
--- a/src/components/JobResults/JobListings.vue
+++ b/src/components/JobResults/JobListings.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="flex-auto bg-brand-gray-2 p-8">
     <ol>
-      <job-listing v-for="job in jobs" :key="job.id" :job="job" />
+      <job-listing v-for="job in pagedJobs" :key="job.id" :job="job" />
     </ol>
   </main>
 </template>
@@ -19,6 +19,11 @@ export default {
     return {
       jobs: [],
     };
+  },
+  computed: {
+    pagedJobs() {
+      return this.jobs.slice(0, 10);
+    },
   },
   async mounted() {
     const result = await axios.get("http://localhost:3000/jobs");

--- a/src/components/JobResults/JobListings.vue
+++ b/src/components/JobResults/JobListings.vue
@@ -9,12 +9,14 @@
         <div class="flex items-center justify-center">
           <router-link
             v-if="previousPage"
+            role="link"
             :to="{ name: 'JobResults', query: { page: previousPage } }"
             class="mx-3 text-sm font-semibold text-brand-blue-1"
             >Previous</router-link
           >
           <router-link
             v-if="nextPage"
+            role="link"
             :to="{ name: 'JobResults', query: { page: nextPage } }"
             class="mx-3 text-sm font-semibold text-brand-blue-1"
             >Next</router-link
@@ -51,7 +53,9 @@ export default {
     nextPage() {
       const nextPage = this.currentPage + 1;
 
-      return nextPage <= this.jobs.length / 10 ? nextPage : undefined;
+      return nextPage <= Math.ceil(this.jobs.length / 10)
+        ? nextPage
+        : undefined;
     },
     pagedJobs() {
       const page = this.currentPage;

--- a/src/components/JobResults/JobListings.vue
+++ b/src/components/JobResults/JobListings.vue
@@ -22,7 +22,11 @@ export default {
   },
   computed: {
     pagedJobs() {
-      return this.jobs.slice(0, 10);
+      const page = Number.parseInt(this.$route.query.page) || 1;
+      const offset = (page - 1) * 10;
+      const total = page * 10;
+
+      return this.jobs.slice(offset, total);
     },
   },
   async mounted() {

--- a/src/components/JobResults/JobListings.vue
+++ b/src/components/JobResults/JobListings.vue
@@ -66,7 +66,8 @@ export default {
     },
   },
   async mounted() {
-    const result = await axios.get("http://localhost:3000/jobs");
+    const baseUrl = import.meta.env.VITE_APP_API_URL;
+    const result = await axios.get(`${baseUrl}/jobs`);
     this.jobs = result.data;
   },
 };

--- a/src/components/JobResults/JobListings.vue
+++ b/src/components/JobResults/JobListings.vue
@@ -3,6 +3,25 @@
     <ol>
       <job-listing v-for="job in pagedJobs" :key="job.id" :job="job" />
     </ol>
+    <div class="mx-auto mt-8">
+      <div class="flex flex-row flex-nowrap">
+        <p class="mx-3 flex-grow text-sm">Page {{ currentPage }}</p>
+        <div class="flex items-center justify-center">
+          <router-link
+            v-if="previousPage"
+            :to="{ name: 'JobResults', query: { page: previousPage } }"
+            class="mx-3 text-sm font-semibold text-brand-blue-1"
+            >Previous</router-link
+          >
+          <router-link
+            v-if="nextPage"
+            :to="{ name: 'JobResults', query: { page: nextPage } }"
+            class="mx-3 text-sm font-semibold text-brand-blue-1"
+            >Next</router-link
+          >
+        </div>
+      </div>
+    </div>
   </main>
 </template>
 
@@ -21,8 +40,21 @@ export default {
     };
   },
   computed: {
+    currentPage() {
+      return Number.parseInt(this.$route.query.page) || 1;
+    },
+    previousPage() {
+      const previousPage = this.currentPage - 1;
+
+      return previousPage >= 1 ? previousPage : undefined;
+    },
+    nextPage() {
+      const nextPage = this.currentPage + 1;
+
+      return nextPage <= this.jobs.length / 10 ? nextPage : undefined;
+    },
     pagedJobs() {
-      const page = Number.parseInt(this.$route.query.page) || 1;
+      const page = this.currentPage;
       const offset = (page - 1) * 10;
       const total = page * 10;
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -24,6 +24,13 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
+  scrollBehavior() {
+    return {
+      top: 0,
+      left: 0,
+      behavior: "smooth",
+    };
+  },
 });
 
 export default router;

--- a/tests/unit/components/JobResults/JobListings.test.js
+++ b/tests/unit/components/JobResults/JobListings.test.js
@@ -67,4 +67,36 @@ describe("JobListings", () => {
       expect(screen.getByText("Page 7")).toBeInTheDocument();
     });
   });
+
+  describe("when the user is on the first page", () => {
+    it("should not show link to previous page", async () => {
+      axios.get.mockResolvedValue({
+        data: Array(15).fill({ id: "1", title: "Vue Developer" }),
+      });
+
+      const $route = createRoute({ page: "1" });
+      renderJobListings($route);
+
+      await screen.findAllByRole("listitem");
+
+      const previousLink = screen.queryByRole("link", { name: /previous/i });
+
+      expect(previousLink).not.toBeInTheDocument();
+    });
+
+    it.only("display link to next page", async () => {
+      axios.get.mockResolvedValue({
+        data: Array(15).fill({ id: "1", title: "Vue Developer" }),
+      });
+
+      const $route = createRoute({ page: "1" });
+      renderJobListings($route);
+
+      await screen.findAllByRole("listitem");
+
+      const nextLink = screen.queryByRole("link", { name: /next/i });
+
+      expect(nextLink).toBeInTheDocument();
+    });
+  });
 });

--- a/tests/unit/components/JobResults/JobListings.test.js
+++ b/tests/unit/components/JobResults/JobListings.test.js
@@ -7,28 +7,14 @@ import { RouterLinkStub } from "@vue/test-utils";
 vi.mock("axios");
 
 describe("JobListings", () => {
-  it("fetches jobs", () => {
-    // overwrite axios.get and return a promise with the data property
-    axios.get.mockResolvedValue({ data: [] });
-    const $route = { query: { page: "1" } };
-
-    render(JobListings, {
-      global: {
-        mocks: {
-          $route,
-        },
-      },
-    });
-
-    expect(axios.get).toHaveBeenCalledWith("http://localhost:3000/jobs");
+  const createRoute = (queryParams = {}) => ({
+    query: {
+      page: "5",
+      ...queryParams,
+    },
   });
 
-  it("displays a maximum of 10 jobs", async () => {
-    axios.get.mockResolvedValue({
-      data: Array(15).fill({ id: "1", title: "Vue Developer" }),
-    });
-    const $route = { query: { page: "1" } };
-
+  const renderJobListings = ($route) => {
     render(JobListings, {
       global: {
         mocks: {
@@ -39,6 +25,26 @@ describe("JobListings", () => {
         },
       },
     });
+  };
+
+  it("fetches jobs", () => {
+    // overwrite axios.get and return a promise with the data property
+    axios.get.mockResolvedValue({ data: [] });
+    const $route = createRoute();
+
+    renderJobListings($route);
+
+    expect(axios.get).toHaveBeenCalledWith("http://localhost:3000/jobs");
+  });
+
+  it("displays a maximum of 10 jobs", async () => {
+    axios.get.mockResolvedValue({
+      data: Array(15).fill({ id: "1", title: "Vue Developer" }),
+    });
+
+    const $route = createRoute({ page: "1" });
+
+    renderJobListings($route);
 
     const jobListings = await screen.findAllByRole("listitem");
     expect(jobListings).toHaveLength(10);

--- a/tests/unit/components/JobResults/JobListings.test.js
+++ b/tests/unit/components/JobResults/JobListings.test.js
@@ -84,7 +84,7 @@ describe("JobListings", () => {
       expect(previousLink).not.toBeInTheDocument();
     });
 
-    it.only("display link to next page", async () => {
+    it("display link to next page", async () => {
       axios.get.mockResolvedValue({
         data: Array(15).fill({ id: "1", title: "Vue Developer" }),
       });
@@ -97,6 +97,39 @@ describe("JobListings", () => {
       const nextLink = screen.queryByRole("link", { name: /next/i });
 
       expect(nextLink).toBeInTheDocument();
+    });
+  });
+
+  describe("when the user is on the last page", () => {
+    it("should not show link to next page", async () => {
+      axios.get.mockResolvedValue({
+        data: Array(15).fill({ id: "1", title: "Vue Developer" }),
+      });
+
+      const $route = createRoute({ page: 2 });
+
+      renderJobListings($route);
+
+      await screen.findAllByRole("listitem");
+
+      const nextLink = screen.queryByRole("link", { name: /next/i });
+
+      expect(nextLink).not.toBeInTheDocument();
+    });
+
+    it("should show link to previous page", async () => {
+      axios.get.mockResolvedValue({
+        data: Array(15).fill({ id: "1", title: "Vue Developer" }),
+      });
+
+      const $route = createRoute({ page: "2" });
+      renderJobListings($route);
+
+      await screen.findAllByRole("listitem");
+
+      const previousLink = screen.queryByRole("link", { name: /previous/i });
+
+      expect(previousLink).toBeInTheDocument();
     });
   });
 });

--- a/tests/unit/components/JobResults/JobListings.test.js
+++ b/tests/unit/components/JobResults/JobListings.test.js
@@ -49,4 +49,22 @@ describe("JobListings", () => {
     const jobListings = await screen.findAllByRole("listitem");
     expect(jobListings).toHaveLength(10);
   });
+
+  describe("when params exclude page number", () => {
+    it("displays page number 1", () => {
+      const $route = createRoute({ page: undefined });
+      renderJobListings($route);
+
+      expect(screen.getByText("Page 1")).toBeInTheDocument();
+    });
+  });
+
+  describe("when params include the page number", () => {
+    it("display the page number", () => {
+      const $route = createRoute({ page: "7" });
+      renderJobListings($route);
+
+      expect(screen.getByText("Page 7")).toBeInTheDocument();
+    });
+  });
 });

--- a/tests/unit/components/JobResults/JobListings.test.js
+++ b/tests/unit/components/JobResults/JobListings.test.js
@@ -34,7 +34,7 @@ describe("JobListings", () => {
 
     renderJobListings($route);
 
-    expect(axios.get).toHaveBeenCalledWith("http://localhost:3000/jobs");
+    expect(axios.get).toHaveBeenCalledWith("http://myfakeapi.com/jobs");
   });
 
   it("displays a maximum of 10 jobs", async () => {

--- a/tests/unit/components/JobResults/JobListings.test.js
+++ b/tests/unit/components/JobResults/JobListings.test.js
@@ -15,7 +15,7 @@ describe("JobListings", () => {
     expect(axios.get).toHaveBeenCalledWith("http://localhost:3000/jobs");
   });
 
-  it("creates a job listing for every job", async () => {
+  it("displays a maximum of 10 jobs", async () => {
     axios.get.mockResolvedValue({
       data: Array(15).fill({ id: "1", title: "Vue Developer" }),
     });
@@ -28,6 +28,6 @@ describe("JobListings", () => {
     });
 
     const jobListings = await screen.findAllByRole("listitem");
-    expect(jobListings).toHaveLength(15);
+    expect(jobListings).toHaveLength(10);
   });
 });

--- a/tests/unit/components/JobResults/JobListings.test.js
+++ b/tests/unit/components/JobResults/JobListings.test.js
@@ -10,7 +10,15 @@ describe("JobListings", () => {
   it("fetches jobs", () => {
     // overwrite axios.get and return a promise with the data property
     axios.get.mockResolvedValue({ data: [] });
-    render(JobListings);
+    const $route = { query: { page: "1" } };
+
+    render(JobListings, {
+      global: {
+        mocks: {
+          $route,
+        },
+      },
+    });
 
     expect(axios.get).toHaveBeenCalledWith("http://localhost:3000/jobs");
   });
@@ -19,8 +27,13 @@ describe("JobListings", () => {
     axios.get.mockResolvedValue({
       data: Array(15).fill({ id: "1", title: "Vue Developer" }),
     });
+    const $route = { query: { page: "1" } };
+
     render(JobListings, {
       global: {
+        mocks: {
+          $route,
+        },
         stubs: {
           "router-link": RouterLinkStub,
         },


### PR DESCRIPTION
When this **PR** get merged

- api endpoint is comming from a .env variable
- we only fetch 10 jobs per page
- add page number to the frontend
- add next and previous button to the frontend
- add test for all new scenario's for dynamic routing